### PR TITLE
fix(deploy): remove node driver registrar preStop hook

### DIFF
--- a/deploy/kubernetes/setup-upcloud-csi.yaml
+++ b/deploy/kubernetes/setup-upcloud-csi.yaml
@@ -227,15 +227,6 @@ spec:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                  [
-                    "/bin/sh",
-                    "-c",
-                    "rm -rf /registration/storage.csi.upcloud.com /registration/storage.csi.upcloud.com-reg.sock",
-                  ]
           env:
             - name: ADDRESS
               value: /csi/csi.sock


### PR DESCRIPTION
Sidecar container `csi-node-driver-registrar` doesn't contain `bin/sh` command. 
[Socket is removed by node driver registrar](https://github.com/kubernetes-csi/node-driver-registrar/pull/61).

This can be observed by copying `PreStop` hook to `PostStart` and check logs `kubectl -n kube-system describe pods/csi-upcloud-node...`