### PR TITLE
fix(driver): add volume expansion constraints

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,20 @@
+name: UpCloud CSI driver test
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    paths:
+      - driver/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v3
+
+      - name: Run
+        run: make test-driver

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,5 @@ clean-tests:
 	KUBECONFIG=$(KUBECONFIG) kubectl delete all --all
 	KUBECONFIG=$(KUBECONFIG) kubectl delete persistentvolumeclaims --all
 
+test-driver:
+	go test -v github.com/UpCloudLtd/upcloud-csi/driver

--- a/driver/controller_test.go
+++ b/driver/controller_test.go
@@ -366,3 +366,23 @@ func TestControllerService_ValidateVolumeCapabilities(t *testing.T) {
 		})
 	}
 }
+
+func TestControllerExpandVolume(t *testing.T) {
+	d := NewMockDriver(nil)
+	wantBytes := int64(30 * giB)
+	r, err := d.ControllerExpandVolume(context.Background(), &csi.ControllerExpandVolumeRequest{
+		VolumeId: "test-vol",
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: wantBytes,
+			LimitBytes:    0,
+		},
+		//VolumeCapability:     &csi.VolumeCapability{},
+	})
+	if err != nil {
+		t.Errorf("ControllerExpandVolume error = %v", err)
+		return
+	}
+	if r.CapacityBytes != wantBytes {
+		t.Errorf("CapacityBytes failed want %d got %d", wantBytes, r.CapacityBytes)
+	}
+}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -64,7 +64,6 @@ type Driver struct {
 
 	healthChecker *HealthChecker
 
-	storage upcloud.Storage
 	// ready defines whether the driver is ready to function. This value will
 	// be used by the `Identity` service via the `Probe()` method.
 	readyMu sync.Mutex // protects ready
@@ -85,7 +84,6 @@ type driverOptions struct {
 	nodeHost     string
 	nodeId       string
 	zone         string
-	upcloudTag   string
 	isController bool
 }
 

--- a/driver/node_test.go
+++ b/driver/node_test.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -72,4 +73,11 @@ func createTempFile(dir, pattern string) (string, error) {
 		return "", err
 	}
 	return f.Name(), f.Close()
+}
+
+func TestNodeExpandVolume(t *testing.T) {
+	d := NewMockDriver(nil)
+	if _, err := d.NodeExpandVolume(context.TODO(), nil); err == nil {
+		t.Error("NodeExpandVolume should return error. Only offline volume expansion is supported and it's handled by controller.")
+	}
 }

--- a/driver/test_utils.go
+++ b/driver/test_utils.go
@@ -3,37 +3,22 @@ package driver
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
-	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 )
 
-var (
-	volCap = &csi.VolumeCapability{
-		AccessType: &csi.VolumeCapability_Mount{
-			Mount: &csi.VolumeCapability_MountVolume{},
-		},
-		AccessMode: &csi.VolumeCapability_AccessMode{
-			Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-		},
-	}
-)
-
 type MockDriver struct {
 	Driver
-	options *driverOptions
+	//options *driverOptions
 	//
 	//srv     *grpc.Server
 	//httpSrv http.Server
 	//
-	mounter Mounter
-	log     *logrus.Entry
+	//mounter Mounter
+	//log     *logrus.Entry
 	//
 	//upcloudclient *upcloudservice.Service
 	//upclouddriver upcloudService
@@ -182,22 +167,6 @@ func (m *mockUpCloudDriver) stopServer(ctx context.Context, uuid string) (*upclo
 	return nil, nil
 }
 
-func (m *mockUpCloudDriver) getDiskSource(volumeID string) string {
-	fullId := strings.Join(strings.Split(volumeID, "-"), "")
-	if len(fullId) <= 20 {
-		return ""
-	}
-
-	link, err := os.Readlink(filepath.Join(diskIDPath, diskPrefix+fullId[:20]))
-	if err != nil {
-		fmt.Println(fmt.Errorf("failed to get the link to source"))
-		return ""
-	}
-	source := "/dev" + strings.TrimPrefix(link, "../..")
-
-	return source
-}
-
 func (m *mockUpCloudDriver) createStorageBackup(ctx context.Context, uuid, title string) (*upcloud.StorageDetails, error) {
 	s := newMockStorage(m.storageSize)
 	s.UUID = uuid
@@ -222,4 +191,9 @@ func (m *mockUpCloudDriver) getStorageBackupByName(ctx context.Context, name str
 	s := newMockBackupStorage(newMockStorage(m.storageSize))
 	s.Title = name
 	return s, nil
+}
+
+func (m *mockUpCloudDriver) waitForStorageState(ctx context.Context, uuid, state string) (*upcloud.StorageDetails, error) {
+	return &upcloud.StorageDetails{
+		Storage: *newMockStorage(m.storageSize)}, nil
 }

--- a/driver/upcloud.go
+++ b/driver/upcloud.go
@@ -43,6 +43,7 @@ type upcloudService interface {
 	createStorageBackup(ctx context.Context, uuid, title string) (*upcloud.StorageDetails, error)
 	listStorageBackups(ctx context.Context, uuid string) ([]upcloud.Storage, error)
 	deleteStorageBackup(ctx context.Context, uuid string) error
+	waitForStorageState(ctx context.Context, uuid, state string) (*upcloud.StorageDetails, error)
 }
 
 func (u *upcloudClient) getStorageByUUID(ctx context.Context, storageUUID string) (*upcloud.StorageDetails, error) {
@@ -293,4 +294,12 @@ func (u *upcloudClient) getStorageBackupByName(ctx context.Context, name string)
 		}
 	}
 	return nil, errUpCloudStorageNotFound
+}
+
+func (u *upcloudClient) waitForStorageState(ctx context.Context, uuid, state string) (*upcloud.StorageDetails, error) {
+	return u.svc.WaitForStorageState(ctx, &request.WaitForStorageStateRequest{
+		UUID:         uuid,
+		DesiredState: state,
+		Timeout:      storageStateTimeout * time.Second,
+	})
 }


### PR DESCRIPTION
- add volume expansion constraints - only offline expansion is supported
- remove unused code
- add test workflow

This will cause driver to report errors if volume is published on node:
`
resize volume "pvc-xyz" by resizer "storage.csi.upcloud.com" failed: rpc error: code = FailedPrecondition desc = volume is currently published on a node
Unable to expand default/xyz because CSI driver storage.csi.upcloud.com only supports offline expansion and volume is currently in-use
`
When volume is unpublished volume resize will succeed:
`
External resizer is resizing volume pvc-xyz
Resize volume succeeded
`