### PR TITLE
chore(driver): refine mounter tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,5 +16,5 @@ jobs:
 
       - uses: actions/setup-go@v3
 
-      - name: Run
-        run: make test-driver
+      - name: Test Driver
+        run: sudo make test-driver

--- a/driver/mounter_test.go
+++ b/driver/mounter_test.go
@@ -1,6 +1,14 @@
 package driver
 
-import "testing"
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
 
 func TestSfdiskOutputGetLastPartition(t *testing.T) {
 	outputMultiple := `
@@ -33,4 +41,168 @@ func TestSfdiskOutputGetLastPartition(t *testing.T) {
 	if want != got {
 		t.Errorf("sfdiskOutputGetLastPartition failed want %s got %s", want, got)
 	}
+}
+
+func TestMounterFilesystem(t *testing.T) {
+	if err := checkSystemRequirements(); err != nil {
+		t.Skipf("skipping test: %s", err.Error())
+	}
+	// create 10MB fake partition
+	part, err := createDeviceFile(1e7)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer os.Remove(part)
+	t.Logf("create fake partition %s", part)
+
+	m := newTestMounter()
+
+	if err := m.format(part, "ext4", nil); err != nil {
+		t.Errorf("Format failed with error: %s", err.Error())
+		return
+	}
+	t.Logf("formated %s", part)
+	s, err := m.GetStatistics(os.TempDir())
+	if err != nil {
+		t.Errorf("GetStatistics failed with error: %s", err.Error())
+		return
+	}
+	t.Logf("got %s statistics", os.TempDir())
+	if s.availableBytes <= 0 {
+		t.Errorf("GetStatistics failed available bytes if zero")
+		return
+	}
+
+	if canMount() {
+		mountPath, err := os.MkdirTemp(os.TempDir(), fmt.Sprintf("%s-mount-path-*", DefaultDriverName))
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer os.RemoveAll(mountPath)
+
+		if err := m.Mount(part, mountPath, "ext4"); err != nil {
+			t.Errorf("Mount failed with error: %s", err.Error())
+			return
+		}
+		isMounted, err := m.IsMounted(mountPath)
+		if err != nil {
+			t.Errorf("IsMounted failed with error: %s", err.Error())
+			return
+		}
+		if !isMounted {
+			t.Errorf("IsMounted returned false")
+			return
+		}
+
+		t.Logf("mounted %s to %s", part, mountPath)
+		if err := m.Unmount(mountPath); err != nil {
+			t.Errorf("Unmount failed with error: %s", err.Error())
+			return
+		}
+		t.Logf("unmounted %s", mountPath)
+	} else {
+		t.Log("skipped mount testing")
+	}
+}
+
+func TestMounterDisk(t *testing.T) {
+	if err := checkSystemRequirements(); err != nil {
+		t.Skipf("skipping test: %s", err.Error())
+	}
+	// create 10MB fake disk
+	disk, err := createDeviceFile(1e7)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer os.Remove(disk)
+	t.Logf("create fake disk device %s", disk)
+	m := newTestMounter()
+
+	// Create partition equivalent to creating /dev/sda1 to device /dev/sda
+	if err := m.createPartition(disk); err != nil {
+		t.Errorf("createPartition failed with error: %s", err.Error())
+		return
+	}
+
+	// check if partition table exists
+	gotFormated, err := m.IsFormatted(disk)
+	if err != nil {
+		t.Errorf("IsFormatted failed with error: %s", err.Error())
+		return
+	}
+	if gotFormated != true {
+		t.Error("IsFormatted failed device should have parition table (GPT)")
+		return
+	}
+
+	// check last partition
+	wantPartition := disk + "p1"
+	gotPartition, err := getLastPartition(disk)
+	if err != nil {
+		t.Errorf("getLastPartition failed with error: %s", err.Error())
+		return
+	}
+	if wantPartition != gotPartition {
+		t.Errorf("getLastPartition failed want %s got %s", wantPartition, gotPartition)
+		return
+	}
+	t.Logf("created new partition %s", wantPartition)
+
+	// Wipe signatures from a device.
+	if err := m.wipeDevice(disk); err != nil {
+		t.Errorf("wipeDevice failed with error: %s", err.Error())
+		return
+	}
+	t.Logf("wiped signatures from a device %s", disk)
+	wantPartition = ""
+	gotPartition, err = getLastPartition(disk)
+	if err != nil {
+		t.Errorf("getLastPartition after wipe failed with error: %s", err.Error())
+		return
+	}
+	if wantPartition != gotPartition {
+		t.Errorf("getLastPartition failed want %s got %s", wantPartition, gotPartition)
+		return
+	}
+	t.Logf("device %s is now empty", disk)
+}
+
+func createDeviceFile(size int64) (string, error) {
+	f, err := os.CreateTemp(os.TempDir(), fmt.Sprintf("%s-disk-*", DefaultDriverName))
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	if err := f.Truncate(size); err != nil {
+		return f.Name(), err
+	}
+	return f.Name(), err
+}
+
+func checkSystemRequirements() error {
+	tools := []string{
+		"mkfs.ext4", "mount", "umount", "blkid", "wipefs", "findmnt", "parted", "sfdisk", "tune2fs", "udevadm",
+	}
+	for _, t := range tools {
+		if _, err := exec.LookPath(t); err != nil {
+			if err == exec.ErrNotFound {
+				return fmt.Errorf("%s executable not found in $PATH", t)
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func newTestMounter() *mounter {
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	return newMounter(logger.WithFields(nil))
+}
+
+func canMount() bool {
+	return os.Getuid() == 0
 }

--- a/driver/node_test.go
+++ b/driver/node_test.go
@@ -3,7 +3,6 @@ package driver
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -22,7 +21,7 @@ func TestVolumeIDToDiskID(t *testing.T) {
 }
 
 func TestGetDiskByID(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), fmt.Sprintf("test-%s-*", DefaultDriverName))
+	tempDir, err := os.MkdirTemp(os.TempDir(), fmt.Sprintf("test-%s-*", DefaultDriverName))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +67,7 @@ func TestGetDiskByID(t *testing.T) {
 }
 
 func createTempFile(dir, pattern string) (string, error) {
-	f, err := ioutil.TempFile(dir, pattern)
+	f, err := os.CreateTemp(dir, pattern)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Test mounter disk and filesystem operations. 

Testing mount points requires root privileges so changed driver workflow to be run using sudo.