### PR TITLE
refactor(release): deploy CRDs separately

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,10 +2,8 @@ project_name: upcloud-csi
 before:
   hooks:
     - make build-manifest && mkdir -p ./temp
-    - ./cmd/upcloud-csi-manifest/upcloud-csi-manifest --output=./temp/{{ .ProjectName }}-deploy.yaml --driver-version={{ if .IsSnapshot }}main{{ else }}v{{ .Version }}{{ end }}
     - ./cmd/upcloud-csi-manifest/upcloud-csi-manifest --crd=true --rbac=false --setup=false --output=./temp/{{ .ProjectName }}-crd.yaml --driver-version={{ if .IsSnapshot }}main{{ else }}v{{ .Version }}{{ end }}
-    - ./cmd/upcloud-csi-manifest/upcloud-csi-manifest --crd=false --rbac=true --setup=false  --output=./temp/{{ .ProjectName }}-rbac.yaml --driver-version={{ if .IsSnapshot }}main{{ else }}v{{ .Version }}{{ end }}
-    - ./cmd/upcloud-csi-manifest/upcloud-csi-manifest --crd=false --rbac=false --setup=true --output=./temp/{{ .ProjectName }}-setup.yaml --driver-version={{ if .IsSnapshot }}main{{ else }}v{{ .Version }}{{ end }}
+    - ./cmd/upcloud-csi-manifest/upcloud-csi-manifest --crd=false --rbac=true --setup=true  --output=./temp/{{ .ProjectName }}-setup.yaml --driver-version={{ if .IsSnapshot }}main{{ else }}v{{ .Version }}{{ end }}
 builds:
   - id: upcloud-csi-plugin
     env:

--- a/cmd/upcloud-csi-manifest/main.go
+++ b/cmd/upcloud-csi-manifest/main.go
@@ -22,7 +22,7 @@ func main() {
 		secretsManifest         = flagSet.Bool("secrets", false, "Include secrets manifest.")
 		setupManifest           = flagSet.Bool("setup", true, "Include setup manifest.")
 		rbacManifest            = flagSet.Bool("rbac", true, "Include RBAC manifest.")
-		crdManifest             = flagSet.Bool("crd", true, "Include CRD manifest.")
+		crdManifest             = flagSet.Bool("crd", false, "Include CRD manifest.")
 		snapshotWebhookManifest = flagSet.Bool("snapshot-webhook", false, "Include snapshot webhook manifest.")
 		driverVersion           = flagSet.String("driver-version", "main", "Use specific driver version to render setup manifest.")
 		upcloudUsername         = flagSet.String("upcloud-username", "", "Use UpCloud username to render secrets manifest. If empty, 'UPCLOUD_USERNAME' environment variable is used.")


### PR DESCRIPTION
CRD objects should be available before applying rest of the objects so that `no matches for kind` errors can be avoided.
This will attach `upcloud-csi-crd.yaml` and `upcloud-csi-setup.yaml` to releases. 