### PR TITLE
fix(driver): wait udev before publishing volume

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -33,15 +33,18 @@ const (
 )
 
 const (
-	// StorageSizeThreshold is a size value for checking if user can provision
-	// additional volumes
+	// StorageSizeThreshold is a size value for checking if user can provision additional volumes.
 	StorageSizeThreshold = 10
-	// ClientTimeout helps to tune for timeout on requests to UpCloud API. Measurement: seconds
+	// ClientTimeout helps to tune for timeout on requests to UpCloud API. Measurement: seconds.
 	ClientTimeout = 120
-	// InitTimeout specifies a time limit for driver initialization in seconds
+	// InitTimeout specifies a time limit for driver initialization in seconds.
 	initTimeout = 30
-	// CheckStorageQuotaTimeout specifies a time limit for checking storage quota in seconds
+	// CheckStorageQuotaTimeout specifies a time limit for checking storage quota in seconds.
 	checkStorageQuotaTimeout = 30
+	// udevDiskTimeout specifies a time limit for waiting disk appear under /dev/disk/by-id.
+	udevDiskTimeout = 30
+	// udevSettleTimeout specifies a time limit for waiting udev event queue to become empty.
+	udevSettleTimeout = 20
 )
 
 // Driver implements the following CSI interfaces:
@@ -55,7 +58,7 @@ type Driver struct {
 	srv     *grpc.Server
 	httpSrv http.Server
 
-	mounter Mounter
+	mounter *mounter
 	log     *logrus.Entry
 
 	upcloudclient *upcloudservice.ServiceContext

--- a/driver/identity.go
+++ b/driver/identity.go
@@ -2,7 +2,6 @@ package driver
 
 import (
 	"context"
-	"github.com/sirupsen/logrus"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/protobuf/ptypes/wrappers"
@@ -10,21 +9,14 @@ import (
 
 // GetPluginInfo returns metadata of the plugin
 func (d *Driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
-	resp := &csi.GetPluginInfoResponse{
+	return &csi.GetPluginInfoResponse{
 		Name: d.options.driverName,
-	}
-
-	d.log.WithFields(logrus.Fields{
-		"response": resp,
-		"method":   "get_plugin_info",
-	}).Info("return plugin info")
-
-	return resp, nil
+	}, nil
 }
 
 // GetPluginCapabilities returns available capabilities of the plugin
 func (d *Driver) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
-	resp := &csi.GetPluginCapabilitiesResponse{
+	return &csi.GetPluginCapabilitiesResponse{
 		Capabilities: []*csi.PluginCapability{
 			{
 				Type: &csi.PluginCapability_Service_{
@@ -48,14 +40,7 @@ func (d *Driver) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCa
 				},
 			},
 		},
-	}
-
-	d.log.WithFields(logrus.Fields{
-		"response": resp,
-		"method":   "get_plugin_capabilities",
-	}).Info("get plugin capabitilies called")
-
-	return resp, nil
+	}, nil
 }
 
 // Probe returns the health and readiness of the plugin

--- a/driver/mounter_test.go
+++ b/driver/mounter_test.go
@@ -62,7 +62,7 @@ func TestMounterFilesystem(t *testing.T) {
 
 	m := newTestMounter()
 
-	if err := m.format(context.Background(), part, "ext4", nil); err != nil {
+	if err := m.createFilesystem(context.Background(), part, "ext4", nil); err != nil {
 		t.Errorf("Format failed with error: %s", err.Error())
 		return
 	}

--- a/driver/node_test.go
+++ b/driver/node_test.go
@@ -9,18 +9,21 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVolumeIDToDiskID(t *testing.T) {
 	volID := "f67db1ca-825b-40aa-a6f4-390ac6ff1b91"
-	want := "f67db1ca825b40aaa6f4"
-	got := volumeIDToDiskID(volID)
+	want := "virtio-f67db1ca825b40aaa6f4"
+	got, err := volumeIDToDiskID(volID)
+	require.NoError(t, err)
 	if want != got {
 		t.Errorf("volumeIDToDiskID('%s') failed want %s got %s", volID, want, got)
 	}
 }
 
-func TestGetDiskByID(t *testing.T) {
+func TestGetBlockDeviceByDiskID(t *testing.T) {
 	tempDir, err := os.MkdirTemp(os.TempDir(), fmt.Sprintf("test-%s-*", DefaultDriverName))
 	if err != nil {
 		t.Fatal(err)
@@ -28,18 +31,25 @@ func TestGetDiskByID(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 	t.Logf("using temp dir %s", tempDir)
 
-	devPath := filepath.Join(tempDir, "dev")
-	t.Logf("using dev path %s", devPath)
-	idPath := filepath.Join(tempDir, diskIDPath)
+	tempDevPath := filepath.Join(tempDir, "dev")
+	t.Logf("using dev path %s", tempDevPath)
+
+	idPath := filepath.Join(tempDir, udevDiskByIDPath)
 	t.Logf("using disk id path %s", idPath)
+
 	if err := os.MkdirAll(idPath, os.ModePerm); err != nil {
 		t.Fatal(err)
 	}
 
 	// Test relative path
-	vda, _ := createTempFile(devPath, "vda")
+	vda, err := createTempFile(tempDevPath, "vda")
+	require.NoError(t, err)
+
 	vdaUUID := uuid.NewString()
-	vdaSymLink := filepath.Join(idPath, diskPrefix+volumeIDToDiskID(vdaUUID))
+	diskID, err := volumeIDToDiskID(vdaUUID)
+	require.NoError(t, err)
+
+	vdaSymLink := filepath.Join(idPath, diskID)
 
 	// using ln command instead of Go's built-in so that link has relative path
 	if err := exec.Command("ln", "-s", fmt.Sprintf("../../%s", filepath.Base(vda)), vdaSymLink).Run(); err != nil {
@@ -47,22 +57,29 @@ func TestGetDiskByID(t *testing.T) {
 	}
 
 	want := vda
-	got := getDiskByID(volumeIDToDiskID(vdaUUID), idPath)
-	if got != want {
-		t.Errorf("getDiskSource('%s') failed want %s got %s", vdaUUID, want, got)
-	}
+	got, err := getBlockDeviceByDiskID(context.TODO(), vdaSymLink)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
 
 	// Test absolute path
-	vdb, _ := createTempFile(devPath, "vdb")
+	vdb, _ := createTempFile(tempDevPath, "vdb")
 	vdbUUID := uuid.NewString()
-	vdbSymLink := filepath.Join(idPath, diskPrefix+volumeIDToDiskID(vdbUUID))
+	diskID, err = volumeIDToDiskID(vdbUUID)
+	require.NoError(t, err)
+	vdbSymLink := filepath.Join(idPath, diskID)
 	if err := os.Symlink(vdb, vdbSymLink); err != nil {
 		t.Fatal(err)
 	}
 	want = vdb
-	got = getDiskByID(volumeIDToDiskID(vdbUUID), idPath)
-	if got != want {
-		t.Errorf("getDiskSource('%s') failed want %s got %s", vdbUUID, want, got)
+	got, err = getBlockDeviceByDiskID(context.TODO(), vdbSymLink)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestNodeExpandVolume(t *testing.T) {
+	d := NewMockDriver(nil)
+	if _, err := d.NodeExpandVolume(context.TODO(), nil); err == nil {
+		t.Error("NodeExpandVolume should return error. Only offline volume expansion is supported and it's handled by controller.")
 	}
 }
 
@@ -72,11 +89,4 @@ func createTempFile(dir, pattern string) (string, error) {
 		return "", err
 	}
 	return f.Name(), f.Close()
-}
-
-func TestNodeExpandVolume(t *testing.T) {
-	d := NewMockDriver(nil)
-	if _, err := d.NodeExpandVolume(context.TODO(), nil); err == nil {
-		t.Error("NodeExpandVolume should return error. Only offline volume expansion is supported and it's handled by controller.")
-	}
 }


### PR DESCRIPTION
- fix: volume publish returned error if node host udev event queue was busy
- refactor: return error instead of empty string if volume ID cannot be mapped to block device
- chore: remove format logic in volume context that is not currently supported
- refactor: remove obsolete Mounter interface and unused methods from mounter type
- chore: remove obsolete log messages from identity methods