### PR TITLE
Ability to retrieve username and password from the environment

### DIFF
--- a/cmd/upcloud-csi-plugin/main.go
+++ b/cmd/upcloud-csi-plugin/main.go
@@ -31,10 +31,10 @@ func main() {
 	}
 
 	if *username == "" {
-		*username = os.Getenv("USERNAME")
+		*username = os.Getenv("UPCLOUD_USERNAME")
 	}
 	if *password == "" {
-		*password = os.Getenv("PASSWORD")
+		*password = os.Getenv("UPCLOUD_PASSWORD")
 	}
 
 	if *version {

--- a/cmd/upcloud-csi-plugin/main.go
+++ b/cmd/upcloud-csi-plugin/main.go
@@ -30,6 +30,13 @@ func main() {
 		log.Fatalln(err)
 	}
 
+	if *username == "" {
+		*username = os.Getenv("USERNAME")
+	}
+	if *password == "" {
+		*password = os.Getenv("PASSWORD")
+	}
+
 	if *version {
 		fmt.Printf("%s - %s (%s)\n", driver.GetVersion(), driver.GetCommit(), driver.GetTreeState()) //nolint: forbidigo // allow printing to console
 		os.Exit(0)


### PR DESCRIPTION
While CLI arguments work, the username and password values are visible to anyone that can get a process list. Further, some control planes (Kubernetes, Mesos, among others), log the CLI arguments to stderr which would then include the UpCloud username and password.

This PR makes it possible to specify those values via environment variables if they aren't provided in the CLI.