### PR TITLE
fix(driver): use udevadm only if available

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -45,7 +45,7 @@ const (
 	// CheckStorageQuotaTimeout specifies a time limit for checking storage quota in seconds.
 	checkStorageQuotaTimeout = 30
 	// udevDiskTimeout specifies a time limit for waiting disk appear under /dev/disk/by-id.
-	udevDiskTimeout = 30
+	udevDiskTimeout = 60
 	// udevSettleTimeout specifies a time limit for waiting udev event queue to become empty.
 	udevSettleTimeout = 20
 )

--- a/driver/filesystem_utils.go
+++ b/driver/filesystem_utils.go
@@ -49,12 +49,15 @@ func getBlockDeviceByDiskID(ctx context.Context, diskID string) (dev string, err
 
 // udevWaitDiskToSettle uses udevadm to wait events in event queue to be handled.
 func udevWaitDiskToSettle(ctx context.Context, path string) error {
-	return exec.CommandContext(ctx, //nolint: gosec // TODO: should we validate path that might not exists? Disabled for now
-		"udevadm",
-		"settle",
-		fmt.Sprintf("--timeout=%d", udevSettleTimeout*time.Second),
-		fmt.Sprintf("--exit-if-exists=%s", path),
-	).Run()
+	if udevadm, err := exec.LookPath("udevadm"); err == nil {
+		return exec.CommandContext(ctx,
+			udevadm,
+			"settle",
+			fmt.Sprintf("--timeout=%d", udevSettleTimeout),
+			fmt.Sprintf("--exit-if-exists=%s", path),
+		).Run()
+	}
+	return nil
 }
 
 // volumeIDToDiskID converts volume ID to disk ID managed by udev e.g. f67db1ca-825b-40aa-a6f4-390ac6ff1b91 -> virtio-f67db1ca825b40aaa6f4.


### PR DESCRIPTION
Currently `udevadm` is missing from our images . Running it inside container is not that straight forward or at least it should be investigated more. For now, use it only if is available.  Our `getBlockDeviceByDiskID` still tries to wait `udevDiskTimeout` seconds to disk to appear after attaching. 