### PR TITLE
avoid master nodes by CSI node plugin

### DIFF
--- a/deploy/kubernetes/setup-upcloud-csi.yaml
+++ b/deploy/kubernetes/setup-upcloud-csi.yaml
@@ -220,9 +220,6 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: csi-upcloud-node-sa
       hostNetwork: true
-      tolerations:
-        - effect: NoSchedule
-          operator: Exists
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
By default it is better to avoid CSI plugin to run on top of the master-nodes. In case it needed, can be adjusted easily.