### PR TITLE
refactor(driver): add new parameters and clean up code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,9 @@ clean-tests:
 	KUBECONFIG=$(KUBECONFIG) kubectl delete all --all
 	KUBECONFIG=$(KUBECONFIG) kubectl delete persistentvolumeclaims --all
 
-test-driver:
-	go test -race -v github.com/UpCloudLtd/upcloud-csi/driver
-
-test-objgen:
-	go test -race -v github.com/UpCloudLtd/upcloud-csi/driver/objgen
-
-test: test-driver test-objgen
+.PHONY: test
+test:
+	go test -race ./...
 
 test-integration:
 	make -C test/integration test

--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,10 @@ clean-tests:
 	KUBECONFIG=$(KUBECONFIG) kubectl delete persistentvolumeclaims --all
 
 test-driver:
-	go test -v github.com/UpCloudLtd/upcloud-csi/driver
+	go test -race -v github.com/UpCloudLtd/upcloud-csi/driver
 
 test-objgen:
-	go test -v github.com/UpCloudLtd/upcloud-csi/driver/objgen
+	go test -race -v github.com/UpCloudLtd/upcloud-csi/driver/objgen
 
 test: test-driver test-objgen
 

--- a/cmd/upcloud-csi-plugin/main.go
+++ b/cmd/upcloud-csi-plugin/main.go
@@ -37,7 +37,7 @@ func main() {
 		address      = flagSet.String("address", driver.DefaultAddress, "Address to serve on")
 		version      = flagSet.Bool("version", false, "Print the version and exit.")
 		isController = flagSet.Bool("is_controller", true, "Run driver with controller included")
-		logLevel     = flagSet.String("log-level", "info", "Loggin level: panic, fatal, error, warn, warning, info, debug or trace")
+		logLevel     = flagSet.String("log-level", "info", "Logging level: panic, fatal, error, warn, warning, info, debug or trace")
 		labels       = flagSet.StringSlice("label", nil, "Apply default labels to all storage devices created by CSI driver, e.g. --label=color=green --label=size=xl")
 	)
 	if err := flagSet.Parse(os.Args[1:]); err != nil {

--- a/cmd/upcloud-csi-plugin/main.go
+++ b/cmd/upcloud-csi-plugin/main.go
@@ -3,82 +3,136 @@ package main
 import (
 	"fmt"
 	"log"
+	"net/url"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/UpCloudLtd/upcloud-csi/driver"
+	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud/client"
+	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud/service"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 )
 
+const (
+	// clientTimeout helps to tune for timeout on requests to UpCloud API. Measurement: seconds.
+	clientTimeout time.Duration = 120 * time.Second
+
+	envUpcloudUsername string = "UPCLOUD_USERNAME"
+	envUpcloudPassword string = "UPCLOUD_PASSWORD"
+	envStorageLabels   string = "STORAGE_LABELS"
+)
+
 func main() {
 	flagSet := pflag.NewFlagSet("default", pflag.ContinueOnError)
-
 	var (
-		endpoint     = flagSet.String("endpoint", "unix:///var/lib/kubelet/plugins/"+driver.DefaultDriverName+"/csi.sock", "CSI endpoint")
-		nodeHost     = flagSet.String("nodehost", "", "Node hostname to determine node's zone and UUID")
+		endpoint     = flagSet.String("endpoint", driver.DefaultEndpoint, "CSI endpoint")
+		nodeHost     = flagSet.String("nodehost", "", "Node's hostname. This should match server's `hostname` in the hub.upcloud.com.")
+		zone         = flagSet.String("zone", "", "The zone in which the driver will be hosted, e.g. de-fra1. Defaults to `nodeHost` zone.")
 		username     = flagSet.String("username", "", "UpCloud username")
 		password     = flagSet.String("password", "", "UpCloud password")
 		driverName   = flagSet.String("driver-name", driver.DefaultDriverName, "Name for the driver")
 		address      = flagSet.String("address", driver.DefaultAddress, "Address to serve on")
 		version      = flagSet.Bool("version", false, "Print the version and exit.")
 		isController = flagSet.Bool("is_controller", true, "Run driver with controller included")
-		logLevel     = flagSet.String("log-level", "warning", "Loggin level: panic, fatal, error, warn, warning, info, debug or trace")
+		logLevel     = flagSet.String("log-level", "info", "Loggin level: panic, fatal, error, warn, warning, info, debug or trace")
+		labels       = flagSet.StringSlice("label", nil, "Apply default labels to all storage devices created by CSI driver, e.g. --label=color=green --label=size=xl")
 	)
-
-	err := flagSet.Parse(os.Args[1:])
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	if *username == "" {
-		*username = os.Getenv("UPCLOUD_USERNAME")
-	}
-	if *password == "" {
-		*password = os.Getenv("UPCLOUD_PASSWORD")
-	}
-
-	if *version {
-		fmt.Printf("%s - %s (%s)\n", driver.GetVersion(), driver.GetCommit(), driver.GetTreeState()) //nolint: forbidigo // allow printing to console
-		os.Exit(0)
-	}
-
-	if *nodeHost == "" {
-		log.Fatalln("nodehost missing")
-	}
-
-	logger, err := newLogger(*logLevel)
-	if err != nil {
+	if err := flagSet.Parse(os.Args[1:]); err != nil {
 		log.Fatal(err)
 	}
 
-	drv, err := driver.NewDriver(
-		logger,
-		driver.WithDriverName(*driverName),
-		driver.WithEndpoint(*endpoint),
-		driver.WithUsername(*username),
-		driver.WithPassword(*password),
-		driver.WithNodeHost(*nodeHost),
-		driver.WithAddress(*address),
-		driver.WithControllerOn(*isController),
-	)
-	if err != nil {
-		log.Fatalln(err)
+	if *version {
+		printVersionAndExit()
 	}
 
-	if err := drv.Run(); err != nil {
+	if *nodeHost == "" {
+		log.Fatalf("nodehost missing")
+	}
+	svc := service.New(newUpcloudClient(*username, *password))
+	logger := newLogger(*logLevel)
+	options := driver.Options{
+		DriverName:    *driverName,
+		Endpoint:      newEndpoint(*endpoint),
+		Address:       newAddress(*address),
+		NodeHost:      *nodeHost,
+		Zone:          *zone,
+		IsController:  *isController,
+		StorageLabels: newLabels(*labels),
+	}
+	drv, err := driver.NewDriver(svc, options, logger, nil)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	if err := drv.Run(driver.NewUpcloudHealthChecker(svc)); err != nil {
 		log.Fatalln(err)
 	}
 }
 
-func newLogger(logLevel string) (*logrus.Logger, error) {
+func printVersionAndExit() {
+	fmt.Printf("%s - %s (%s)\n", driver.GetVersion(), driver.GetCommit(), driver.GetTreeState()) //nolint: forbidigo // allow printing to console
+	os.Exit(0)
+}
+
+func newUpcloudClient(username, password string) *client.Client {
+	if username == "" {
+		username = os.Getenv(envUpcloudUsername)
+	}
+	if password == "" {
+		password = os.Getenv(envUpcloudPassword)
+	}
+	return client.New(username, password, client.WithTimeout(clientTimeout))
+}
+
+func newAddress(addr string) *url.URL {
+	addressURL, err := url.Parse(addr)
+	if err != nil {
+		log.Fatalf("unable to parse address: %v", err)
+	}
+	return addressURL
+}
+
+func newEndpoint(endpoint string) *url.URL {
+	endpointURL, err := url.Parse(endpoint)
+	if err != nil {
+		log.Fatalf("unable to parse endpoint: %v", err)
+	}
+	// CSI plugins talk only over UNIX sockets currently
+	if endpointURL.Scheme != "unix" {
+		log.Fatalf("currently only unix domain sockets are supported, have: %s", endpointURL.Scheme)
+	}
+	return endpointURL
+}
+
+func newLogger(logLevel string) *logrus.Logger {
 	lv, err := logrus.ParseLevel(logLevel)
 	if err != nil {
-		return nil, err
+		log.Fatal(err)
 	}
 	logger := logrus.New()
 	logger.SetLevel(lv)
 	if logger.GetLevel() > logrus.InfoLevel {
 		logger.WithField("level", logger.GetLevel().String()).Warn("using log level higher than INFO is not recommended in production")
 	}
-	return logger, nil
+	return logger
+}
+
+func newLabels(labels []string) []upcloud.Label {
+	if len(labels) == 0 {
+		labels = strings.Split(os.Getenv(envStorageLabels), ",")
+	}
+	r := make([]upcloud.Label, 0)
+	for _, l := range labels {
+		if l == "" {
+			continue
+		}
+		c := strings.SplitN(l, "=", 2)
+		if len(c) == 2 {
+			r = append(r, upcloud.Label{Key: c[0], Value: c[1]})
+		}
+	}
+	return r
 }

--- a/cmd/upcloud-csi-plugin/main_test.go
+++ b/cmd/upcloud-csi-plugin/main_test.go
@@ -20,10 +20,4 @@ func TestRun(t *testing.T) {
 		log.Printf("%s - %s (%s)\n", driver.GetVersion(), driver.GetCommit(), driver.GetTreeState())
 		os.Exit(0)
 	}
-
-	d := driver.NewMockDriver(nil)
-
-	if err := d.Run(); err != nil {
-		log.Fatalln(err)
-	}
 }

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -134,7 +134,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			Title: volumeName,
 		}
 		logWithServiceRequest(log, volumeReq).Info("cloning volume")
-		vol, err = d.svc.cloneStorage(ctx, volumeReq)
+		vol, err = d.svc.cloneStorage(ctx, volumeReq, d.options.StorageLabels...)
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/UpCloudLtd/upcloud-go-api/v5/upcloud"
-	"github.com/UpCloudLtd/upcloud-go-api/v5/upcloud/request"
+	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud/request"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
@@ -57,8 +57,8 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 				continue // nothing to do
 			}
 
-			if region != d.options.zone {
-				return nil, status.Errorf(codes.ResourceExhausted, "volume can be only created in region: %q, got: %q", d.options.zone, region)
+			if region != d.options.Zone {
+				return nil, status.Errorf(codes.ResourceExhausted, "volume can be only created in region: %q, got: %q", d.options.Zone, region)
 			}
 		}
 	}
@@ -66,7 +66,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	volumeName := req.Name
 
 	// get volume first, and skip if exists
-	volumes, err := d.upclouddriver.getStorageByName(ctx, volumeName)
+	volumes, err := d.svc.getStorageByName(ctx, volumeName)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -116,7 +116,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		}
 		log := log.WithField(logVolumeSourceKey, sourceID)
 		log.Info("getting source storage by uuid")
-		src, err := d.upclouddriver.getStorageByUUID(ctx, sourceID)
+		src, err := d.svc.getStorageByUUID(ctx, sourceID)
 		if err != nil {
 			if errors.Is(err, errUpCloudStorageNotFound) {
 				return nil, status.Errorf(codes.NotFound, "could not retrieve source volume by ID: %s", err.Error())
@@ -124,17 +124,17 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			return nil, status.Errorf(codes.InvalidArgument, err.Error())
 		}
 		log.Info("checking that source storage is online")
-		if err := d.upclouddriver.requireStorageOnline(ctx, &src.Storage); err != nil {
+		if err := d.svc.requireStorageOnline(ctx, &src.Storage); err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 		volumeReq := &request.CloneStorageRequest{
 			UUID:  src.Storage.UUID,
-			Zone:  d.options.zone,
+			Zone:  d.options.Zone,
 			Tier:  tier,
 			Title: volumeName,
 		}
 		logWithServiceRequest(log, volumeReq).Info("cloning volume")
-		vol, err = d.upclouddriver.cloneStorage(ctx, volumeReq)
+		vol, err = d.svc.cloneStorage(ctx, volumeReq)
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
@@ -143,20 +143,21 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		if storageSizeGB > vol.Storage.Size {
 			log.WithField("new_size", storageSizeGB).Info("resizing volume")
 			// resize cloned storage and delete backup taken during resize operation as this is newly created storage
-			if vol, err = d.upclouddriver.resizeStorage(ctx, vol.Storage.UUID, storageSizeGB, true); err != nil {
+			if vol, err = d.svc.resizeStorage(ctx, vol.Storage.UUID, storageSizeGB, true); err != nil {
 				return nil, status.Error(codes.Internal, err.Error())
 			}
 		}
 	} else {
 		volumeReq := &request.CreateStorageRequest{
-			Zone:  d.options.zone,
-			Title: volumeName,
-			Size:  storageSizeGB,
-			Tier:  tier,
+			Zone:   d.options.Zone,
+			Title:  volumeName,
+			Size:   storageSizeGB,
+			Tier:   tier,
+			Labels: d.options.StorageLabels,
 		}
 
 		logWithServiceRequest(log, volumeReq).Info("creating volume")
-		if vol, err = d.upclouddriver.createStorage(ctx, volumeReq); err != nil {
+		if vol, err = d.svc.createStorage(ctx, volumeReq); err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 	}
@@ -168,7 +169,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			AccessibleTopology: []*csi.Topology{
 				{
 					Segments: map[string]string{
-						"region": d.options.zone,
+						"region": d.options.Zone,
 					},
 				},
 			},
@@ -186,7 +187,7 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 	}
 
 	logWithServerContext(ctx, d.log).WithField(logVolumeIDKey, req.GetVolumeId()).Info("deleting volume")
-	err := d.upclouddriver.deleteStorage(ctx, req.VolumeId)
+	err := d.svc.deleteStorage(ctx, req.VolumeId)
 	if err != nil && !errors.Is(err, errUpCloudStorageNotFound) {
 		return &csi.DeleteVolumeResponse{}, err
 	}
@@ -212,7 +213,7 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 		return nil, status.Error(codes.Unimplemented, "read only Volumes are not supported")
 	}
 
-	server, err := d.upclouddriver.getServerByHostname(ctx, req.NodeId)
+	server, err := d.svc.getServerByHostname(ctx, req.NodeId)
 	if err != nil {
 		if errors.Is(err, errUpCloudServerNotFound) {
 			return nil, status.Error(codes.NotFound, err.Error())
@@ -222,7 +223,7 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 
 	// check if volume exist before trying to attach it
 	log.Info("getting storage by uuid")
-	volume, err := d.upclouddriver.getStorageByUUID(ctx, req.VolumeId)
+	volume, err := d.svc.getStorageByUUID(ctx, req.VolumeId)
 	if err != nil {
 		if errors.Is(err, errUpCloudStorageNotFound) {
 			return nil, status.Error(codes.NotFound, err.Error())
@@ -231,7 +232,7 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 	}
 
 	log.Info("checking that storage is online")
-	if err = d.upclouddriver.requireStorageOnline(ctx, &volume.Storage); err != nil {
+	if err = d.svc.requireStorageOnline(ctx, &volume.Storage); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
@@ -256,7 +257,7 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 	}
 
 	log.Info("attaching storage to node")
-	err = d.upclouddriver.attachStorage(ctx, req.VolumeId, server.UUID)
+	err = d.svc.attachStorage(ctx, req.VolumeId, server.UUID)
 	if err != nil {
 		// already attached to the node
 		return nil, err
@@ -278,7 +279,7 @@ func (d *Driver) ControllerUnpublishVolume(ctx context.Context, req *csi.Control
 
 	log.Info("getting storage by uuid")
 	// check if volume exist before trying to detach it
-	_, err := d.upclouddriver.getStorageByUUID(ctx, req.GetVolumeId())
+	_, err := d.svc.getStorageByUUID(ctx, req.GetVolumeId())
 	if err != nil {
 		if errors.Is(err, errUpCloudStorageNotFound) {
 			return &csi.ControllerUnpublishVolumeResponse{}, nil
@@ -288,13 +289,13 @@ func (d *Driver) ControllerUnpublishVolume(ctx context.Context, req *csi.Control
 
 	// TODO:  If node ID is not set, the SP MUST unpublish the volume from all nodes it is published to.
 	log.Info("getting server by hostname")
-	server, err := d.upclouddriver.getServerByHostname(ctx, req.GetNodeId())
+	server, err := d.svc.getServerByHostname(ctx, req.GetNodeId())
 	if err != nil {
 		return nil, err
 	}
 
 	log.Info("detaching volume")
-	err = d.upclouddriver.detachStorage(ctx, req.VolumeId, server.UUID)
+	err = d.svc.detachStorage(ctx, req.VolumeId, server.UUID)
 	if err != nil {
 		return nil, err
 	}
@@ -323,7 +324,7 @@ func (d *Driver) ValidateVolumeCapabilities(ctx context.Context, req *csi.Valida
 
 	log.Info("getting storage by uuid")
 	// check if volume exist before trying to validate it
-	if _, err := d.upclouddriver.getStorageByUUID(ctx, req.VolumeId); err != nil {
+	if _, err := d.svc.getStorageByUUID(ctx, req.VolumeId); err != nil {
 		if errors.Is(err, errUpCloudStorageNotFound) {
 			return nil, status.Error(codes.NotFound, err.Error())
 		}
@@ -357,7 +358,7 @@ func (d *Driver) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (
 		return nil, status.Error(codes.Aborted, "failed to parse starting_token")
 	}
 	log.Info("getting list of storages")
-	volumes, err := d.upclouddriver.listStorage(ctx, d.options.zone)
+	volumes, err := d.svc.listStorage(ctx, d.options.Zone)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "listvolumes failed with: %s", err.Error())
 	}
@@ -416,7 +417,7 @@ func (d *Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequ
 	}
 	log := logWithServerContext(ctx, d.log)
 	log.Info("getting storage backup by name")
-	s, err := d.upclouddriver.getStorageBackupByName(ctx, req.GetName())
+	s, err := d.svc.getStorageBackupByName(ctx, req.GetName())
 	if err != nil && !errors.Is(err, errUpCloudStorageNotFound) {
 		return nil, status.Errorf(codes.Internal, "createsnapshot failed with: %s", err.Error())
 	}
@@ -426,7 +427,7 @@ func (d *Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequ
 	}
 	if s == nil {
 		log.Info("creating strorage backup")
-		sd, err := d.upclouddriver.createStorageBackup(ctx, req.GetSourceVolumeId(), req.GetName())
+		sd, err := d.svc.createStorageBackup(ctx, req.GetSourceVolumeId(), req.GetName())
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "createsnapshot failed with: %s", err.Error())
 		}
@@ -452,8 +453,8 @@ func (d *Driver) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequ
 	}
 	// Delete should succeed if snapshot is not found or an invalid snapshot id is used.
 	if isValidStorageUUID(snapID) {
-		if err := d.upclouddriver.deleteStorageBackup(ctx, snapID); err != nil {
-			var svcError *upcloud.Error
+		if err := d.svc.deleteStorageBackup(ctx, snapID); err != nil {
+			var svcError *upcloud.Problem
 			if errors.As(err, &svcError) && svcError.Status != http.StatusNotFound {
 				return nil, status.Errorf(codes.Internal, err.Error())
 			}
@@ -486,7 +487,7 @@ func (d *Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReques
 	if snapID := req.GetSnapshotId(); snapID != "" { //nolint: nestif // TODO: refactor
 		log = log.WithField("snapshot_id", snapID)
 		log.Info("getting storage snapshots by ID")
-		s, err := d.upclouddriver.getStorageByUUID(ctx, snapID)
+		s, err := d.svc.getStorageByUUID(ctx, snapID)
 		if err != nil {
 			if errors.Is(err, errUpCloudStorageNotFound) {
 				return &csi.ListSnapshotsResponse{
@@ -499,7 +500,7 @@ func (d *Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReques
 	} else {
 		log.Info("getting list of storage snapshots")
 		// NOTE: SourceVolumeId can also be empty
-		backups, err = d.upclouddriver.listStorageBackups(ctx, req.GetSourceVolumeId())
+		backups, err = d.svc.listStorageBackups(ctx, req.GetSourceVolumeId())
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "listsnapshots failed with: %s", err.Error())
 		}
@@ -534,7 +535,7 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, req *csi.Controller
 	log := logWithServerContext(ctx, d.log).WithField(logVolumeIDKey, req.GetVolumeId())
 
 	log.Info("getting storage by uuid")
-	volume, err := d.upclouddriver.getStorageByUUID(ctx, volumeID)
+	volume, err := d.svc.getStorageByUUID(ctx, volumeID)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "could not retrieve existing volumes: %v", err)
 	}
@@ -568,13 +569,13 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, req *csi.Controller
 
 	if isBlockDevice {
 		log.Info("resizing block device")
-		_, err = d.upclouddriver.resizeBlockDevice(ctx, volume.UUID, int(resizeGigaBytes))
+		_, err = d.svc.resizeBlockDevice(ctx, volume.UUID, int(resizeGigaBytes))
 		if err != nil {
 			d.log.Errorf("cannot resizeBlockDevice volume %s: %s", volumeID, err.Error())
 		}
 	} else {
 		log.Info("resizing volume")
-		_, err = d.upclouddriver.resizeStorage(ctx, volume.UUID, int(resizeGigaBytes), false)
+		_, err = d.svc.resizeStorage(ctx, volume.UUID, int(resizeGigaBytes), false)
 		if err != nil {
 			d.log.Errorf("cannot resizeStorage volume %s: %s", volumeID, err.Error())
 		}

--- a/driver/controller_internal_test.go
+++ b/driver/controller_internal_test.go
@@ -1,11 +1,11 @@
-package driver //nolint:testpackage // use conventional naming for now
+package driver
 
 import (
 	"context"
 	"reflect"
 	"testing"
 
-	"github.com/UpCloudLtd/upcloud-go-api/v5/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/stretchr/testify/assert"
 )
@@ -194,7 +194,7 @@ func TestControllerService_CreateVolume(t *testing.T) {
 		tt := testCase
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			d := NewMockDriver(&mockUpCloudDriver{
+			d := NewMockDriver(&mockUpCloudService{
 				volumeNameExists: tt.volumeNameExists,
 				volumeUUIDExists: tt.volumeUUIDExists,
 				storageSize:      10,

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -113,12 +113,12 @@ func NewDriver(svc *upsvc.Service, options Options, logger *logrus.Logger, fs Fi
 		}
 	}
 	if fs == nil {
-		fs = newNodeFilesystem(logEntyFromOptions(logger, options))
+		fs = newNodeFilesystem(logEntryFromOptions(logger, options))
 	}
 	return &Driver{
 		options: options,
 		fs:      fs,
-		log:     logEntyFromOptions(logger, options),
+		log:     logEntryFromOptions(logger, options),
 		svc:     &upCloudService{svc: svc},
 	}, nil
 }
@@ -283,7 +283,7 @@ func getNodeHost(ctx context.Context, svc *upsvc.Service, nodeHost string) (*upc
 	return nil, fmt.Errorf("CSI user account doesn't have node with hostname '%s' defined", nodeHost)
 }
 
-func logEntyFromOptions(logger *logrus.Logger, options Options) *logrus.Entry {
+func logEntryFromOptions(logger *logrus.Logger, options Options) *logrus.Entry {
 	hostname, err := os.Hostname()
 	if err != nil {
 		hostname = "localhost"

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	// DefaultDriverName defines the DriverName that is used in Kubernetes and the CSI
-	// system for the canonical, official DriverName of this plugin.
+	// DefaultDriverName defines the name that is used in Kubernetes and the CSI
+	// system for the canonical, official name of this plugin.
 	DefaultDriverName = "storage.csi.upcloud.com"
 	// DefaultAddress is the default address that the csi plugin will serve its
 	// http handler on.

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -8,36 +8,32 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
-	"path/filepath"
+	"os/signal"
 	"sync"
+	"syscall"
 	"time"
 
+	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud/request"
+	upsvc "github.com/UpCloudLtd/upcloud-go-api/v6/upcloud/service"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/sirupsen/logrus"
-
-	"github.com/UpCloudLtd/upcloud-go-api/v5/upcloud"
-	upcloudclient "github.com/UpCloudLtd/upcloud-go-api/v5/upcloud/client"
-	"github.com/UpCloudLtd/upcloud-go-api/v5/upcloud/request"
-	upcloudservice "github.com/UpCloudLtd/upcloud-go-api/v5/upcloud/service"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 )
 
 const (
-	// DefaultDriverName defines the driverName that is used in Kubernetes and the CSI
-	// system for the canonical, official driverName of this plugin.
+	// DefaultDriverName defines the DriverName that is used in Kubernetes and the CSI
+	// system for the canonical, official DriverName of this plugin.
 	DefaultDriverName = "storage.csi.upcloud.com"
 	// DefaultAddress is the default address that the csi plugin will serve its
 	// http handler on.
-	DefaultAddress = "127.0.0.1:13071"
-)
-
-const (
+	DefaultAddress = "tcp://127.0.0.1:13071"
+	// DefaultEndpoint is the default endpoint that the csi plugin will serve its
+	// GRPC handlers on.
+	DefaultEndpoint = "unix:///var/lib/kubelet/plugins/" + DefaultDriverName + "/csi.sock"
 	// storageSizeThreshold is a size value for checking if user can provision additional volumes.
 	storageSizeThreshold = 10
-	// clientTimeout helps to tune for timeout on requests to UpCloud API. Measurement: seconds.
-	clientTimeout = 120
 	// healthTimeout specifies a time limit for health HTTP server in seconds.
 	healthTimeout = 15
 	// InitTimeout specifies a time limit for driver initialization in seconds.
@@ -56,18 +52,12 @@ const (
 //	csi.ControllerServer
 //	csi.NodeServer
 type Driver struct {
-	options *driverOptions
-
-	srv     *grpc.Server
-	httpSrv http.Server
-
-	fs  Filesystem
-	log *logrus.Entry
-
-	upcloudclient *upcloudservice.Service
-	upclouddriver upcloudService
-
-	healthChecker *HealthChecker
+	options Options
+	grpcSrv *grpc.Server
+	httpSrv *http.Server
+	fs      Filesystem
+	log     *logrus.Entry
+	svc     service
 
 	// ready defines whether the driver is ready to function. This value will
 	// be used by the `Identity` service via the `Probe()` method.
@@ -75,193 +65,192 @@ type Driver struct {
 	ready   bool
 }
 
-type driverOptions struct {
-	username string
-	password string
-
-	driverName   string
-	endpoint     string
-	address      string
-	nodeHost     string
-	nodeID       string
-	zone         string
-	isController bool
+type Options struct {
+	DriverName    string
+	Endpoint      *url.URL
+	Address       *url.URL
+	NodeHost      string
+	Zone          string
+	IsController  bool
+	StorageLabels []upcloud.Label
 }
 
 // NewDriver returns a CSI plugin that contains the necessary gRPC
 // interfaces to interact with Kubernetes over unix domain sockets for
 // managing Upcloud Block Storage.
-func NewDriver(logger *logrus.Logger, options ...func(*driverOptions)) (*Driver, error) {
+func NewDriver(svc *upsvc.Service, options Options, logger *logrus.Logger, fs Filesystem) (*Driver, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*initTimeout)
 	defer cancel()
 
-	driverOpts := &driverOptions{}
-
-	for _, option := range options {
-		option(driverOpts)
+	if options.DriverName == "" {
+		options.DriverName = DefaultDriverName
 	}
-
-	if driverOpts.driverName == "" {
-		driverOpts.driverName = DefaultDriverName
+	if options.Endpoint == nil {
+		options.Endpoint, _ = url.Parse(DefaultEndpoint)
 	}
-
-	// Authenticate by passing your account login credentials to the client
-	c := upcloudclient.New(driverOpts.username, driverOpts.password, upcloudclient.WithTimeout((time.Second * clientTimeout)))
-
-	// Create the service object
-	svc := upcloudservice.New(c)
-	acc, err := svc.GetAccount(ctx)
+	if options.Address == nil {
+		options.Address, _ = url.Parse(DefaultAddress)
+	}
+	account, err := svc.GetAccount(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to login in API: %w", err)
 	}
+	logger.WithField("username", account.UserName).Info("init driver")
 
-	serverDetails, err := determineServer(ctx, svc, driverOpts.nodeHost)
+	srv, err := getNodeHost(ctx, svc, options.NodeHost)
 	if err != nil {
-		return nil, fmt.Errorf("unable to list servers: %w", err)
+		logger.WithField("hostname", options.NodeHost).WithError(err).Warn("unable to find server by hostname")
+	} else if options.Zone == "" {
+		options.Zone = srv.Zone
+	}
+	if err := validateZone(ctx, svc, options.Zone); err != nil {
+		return nil, err
 	}
 
-	driverOpts.zone = serverDetails.Server.Zone
-	driverOpts.nodeID = serverDetails.Server.UUID
-
-	healthChecker := NewHealthChecker(&upcloudHealthChecker{account: svc.GetAccount})
-	hostname, err := os.Hostname()
-	if err != nil {
-		hostname = "localhost"
+	if options.IsController {
+		if quotaDetails, err := checkStorageQuota(svc, account); err != nil {
+			logger.WithError(err).WithField("details", quotaDetails).Warn(err)
+		}
 	}
-	log := logger.WithFields(logrus.Fields{
-		"region":   driverOpts.zone,
-		"node_id":  driverOpts.nodeHost,
-		"hostname": hostname,
-	})
-	log.WithField("username", acc.UserName).Info("init driver")
+	if fs == nil {
+		fs = newNodeFilesystem(logEntyFromOptions(logger, options))
+	}
 	return &Driver{
-		options: driverOpts,
-		fs:      newNodeFilesystem(log),
-		log:     log,
-
-		healthChecker: healthChecker,
-		upcloudclient: svc,
-		upclouddriver: &upcloudClient{svc: svc},
+		options: options,
+		fs:      fs,
+		log:     logEntyFromOptions(logger, options),
+		svc:     &upCloudService{svc: svc},
 	}, nil
 }
 
-func UseFilesystem(d *Driver, fs Filesystem) (*Driver, error) {
-	if d.ready {
-		return d, errors.New("Driver is already initialized")
+func (d *Driver) cleanUpSocket(socketPath string) error {
+	if _, err := os.Stat(socketPath); os.IsNotExist(err) {
+		return nil
 	}
-	d.fs = fs
-	return d, nil
-}
+	d.log.WithField("socket", socketPath).Info("removing socket")
 
-func determineServer(ctx context.Context, svc *upcloudservice.Service, nodeHost string) (*upcloud.ServerDetails, error) {
-	servers, err := svc.GetServers(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't fetch servers list")
+	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove unix domain socket file %s, error: %w", socketPath, err)
 	}
-	for _, s := range servers.Servers {
-		if nodeHost == s.Hostname {
-			r := request.GetServerDetailsRequest{UUID: s.UUID}
-			serverdetails, err := svc.GetServerDetails(ctx, &r)
-			if err != nil {
-				return nil, err
-			}
-			return serverdetails, nil
-		}
-	}
-	return nil, fmt.Errorf("node %s not found", nodeHost)
+	return nil
 }
 
 // Run starts the CSI plugin by communication over the given endpoint.
-func (d *Driver) Run() error { //nolint: funlen // TODO: refactor
-	u, err := url.Parse(d.options.endpoint)
-	if err != nil {
-		return fmt.Errorf("unable to parse address: %w", err)
-	}
-
-	grpcAddr := path.Join(u.Host, filepath.FromSlash(u.Path))
-	if u.Host == "" {
-		grpcAddr = filepath.FromSlash(u.Path)
-	}
-
-	// CSI plugins talk only over UNIX sockets currently
-	if u.Scheme != "unix" {
-		return fmt.Errorf("currently only unix domain sockets are supported, have: %s", u.Scheme)
-	}
+func (d *Driver) Run(checks ...HealthCheck) error {
 	// remove the socket if it's already there. This can happen if we
 	// deploy a new version and the socket was created from the old running
 	// plugin.
-	d.log.WithField("socket", grpcAddr).Info("removing socket")
-
-	if err := os.Remove(grpcAddr); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove unix domain socket file %s, error: %w", grpcAddr, err)
+	if err := d.cleanUpSocket(d.options.Endpoint.Path); err != nil {
+		return err
 	}
 
-	grpcListener, err := net.Listen(u.Scheme, grpcAddr)
+	d.log.WithFields(logrus.Fields{
+		"endpoint":   d.options.Endpoint.String(),
+		"health_url": fmt.Sprintf("http://%s/health", d.options.Address.Host),
+	}).Info("starting servers")
+
+	d.ready = true
+	var eg errgroup.Group
+	eg.Go(func() error {
+		return d.runGRPC()
+	})
+	eg.Go(func() error {
+		return d.runHTTP(checks...)
+	})
+	go d.listenSyscalls()
+	return eg.Wait()
+}
+
+func (d *Driver) runHTTP(checks ...HealthCheck) error {
+	httpListener, err := net.Listen(d.options.Address.Scheme, d.options.Address.Host)
 	if err != nil {
 		return fmt.Errorf("failed to listen: %w", err)
 	}
-
-	if d.options.isController {
-		quotaDetails, err := d.checkStorageQuota()
-		if err != nil && quotaDetails != nil {
-			d.log.WithError(err).WithField("details", quotaDetails).Warn(err)
-		} else if err != nil {
-			d.log.WithError(err).Error("quota request failed")
-		}
-	}
-
-	d.srv = grpc.NewServer(grpc.UnaryInterceptor(serverLogMiddleware(d.log)))
-	csi.RegisterIdentityServer(d.srv, d)
-	csi.RegisterControllerServer(d.srv, d)
-	csi.RegisterNodeServer(d.srv, d)
-
-	httpListener, err := net.Listen("tcp", d.options.address)
-	if err != nil {
-		return fmt.Errorf("failed to listen: %w", err)
-	}
+	healthChecker := NewHealthChecker(checks...)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		err := d.healthChecker.Check(r.Context())
+		err := healthChecker.Check(r.Context())
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		w.WriteHeader(http.StatusOK)
 	})
-	d.httpSrv = http.Server{
+	d.httpSrv = &http.Server{
 		Handler:           mux,
 		ReadHeaderTimeout: healthTimeout * time.Second,
 	}
-
-	d.ready = true // we're now ready to go!
-	d.log.WithFields(logrus.Fields{
-		"grpc_addr": grpcAddr,
-		"http_addr": d.options.address,
-	}).Info("starting server")
-
-	var eg errgroup.Group
-	eg.Go(func() error {
-		return d.srv.Serve(grpcListener)
-	})
-	eg.Go(func() error {
-		return d.httpSrv.Serve(httpListener)
-	})
-
-	return eg.Wait()
+	return d.httpSrv.Serve(httpListener)
 }
 
-func (d *Driver) checkStorageQuota() (map[string]int, error) {
+func (d *Driver) runGRPC() error {
+	grpcListener, err := net.Listen(d.options.Endpoint.Scheme, d.options.Endpoint.Path)
+	if err != nil {
+		return fmt.Errorf("failed to listen: %w", err)
+	}
+
+	d.grpcSrv = grpc.NewServer(grpc.UnaryInterceptor(serverLogMiddleware(d.log)))
+	csi.RegisterIdentityServer(d.grpcSrv, d)
+	csi.RegisterControllerServer(d.grpcSrv, d)
+	csi.RegisterNodeServer(d.grpcSrv, d)
+
+	return d.grpcSrv.Serve(grpcListener)
+}
+
+func (d *Driver) listenSyscalls() {
+	// Listen for syscall signals for process to interrupt/quit
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	sig := <-sigCh
+	signal.Stop(sigCh)
+	d.log.WithField("signal", sig).Info("received OS signal shutting down")
+	d.Stop()
+	close(sigCh)
+}
+
+// Stop stops the plugin.
+func (d *Driver) Stop() {
+	d.readyMu.Lock()
+	d.ready = false
+	d.readyMu.Unlock()
+
+	d.log.WithField("health_url", fmt.Sprintf("http://%s/health", d.options.Address.Host)).Info("stopping HTTP server")
+	if err := d.httpSrv.Close(); err != nil {
+		d.log.Error(err)
+	}
+	d.log.WithField("endpoint", d.options.Endpoint.String()).Info("stopping GRPC server gracefully")
+	d.grpcSrv.GracefulStop()
+	if err := d.cleanUpSocket(d.options.Endpoint.Path); err != nil {
+		d.log.Error(err)
+	}
+}
+
+func validateZone(ctx context.Context, svc *upsvc.Service, zone string) error {
+	if zone == "" {
+		return errors.New("zone is not selected")
+	}
+	r, err := svc.GetZones(ctx)
+	if err != nil {
+		return err
+	}
+	for _, z := range r.Zones {
+		if z.ID == zone {
+			return nil
+		}
+	}
+	return fmt.Errorf("'%s' is not valid UpCloud zone", zone)
+}
+
+func checkStorageQuota(svc *upsvc.Service, account *upcloud.Account) (map[string]int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*checkStorageQuotaTimeout)
 	defer cancel()
-	account, err := d.upcloudclient.GetAccount(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve account details: %w", err)
-	}
+
+	storageDetails := make(map[string]int)
 	ssdLimit := account.ResourceLimits.StorageSSD
 
-	storages, err := d.upcloudclient.GetStorages(ctx, &request.GetStoragesRequest{})
+	storages, err := svc.GetStorages(ctx, &request.GetStoragesRequest{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve server's storage details: %w", err)
+		return storageDetails, fmt.Errorf("unable to retrieve server's storage details: %w", err)
 	}
 
 	total := 0
@@ -278,83 +267,30 @@ func (d *Driver) checkStorageQuota() (map[string]int, error) {
 		return storageDetails, fmt.Errorf("available storage size may be insufficient for correct work of CSI controller")
 	}
 
-	return nil, err
+	return storageDetails, err
 }
 
-// Stop stops the plugin.
-func (d *Driver) Stop() {
-	d.readyMu.Lock()
-	d.ready = false
-	d.readyMu.Unlock()
-
-	d.log.Info("server stopped")
-	d.srv.Stop()
-}
-
-func WithEndpoint(endpoint string) func(*driverOptions) {
-	return func(o *driverOptions) {
-		o.endpoint = endpoint
+func getNodeHost(ctx context.Context, svc *upsvc.Service, nodeHost string) (*upcloud.Server, error) {
+	servers, err := svc.GetServers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't fetch servers list")
 	}
-}
-
-func WithDriverName(driverName string) func(options *driverOptions) {
-	return func(o *driverOptions) {
-		o.driverName = driverName
+	for _, s := range servers.Servers {
+		if nodeHost == s.Hostname {
+			return &s, nil
+		}
 	}
+	return nil, fmt.Errorf("CSI user account doesn't have node with hostname '%s' defined", nodeHost)
 }
 
-func WithAddress(address string) func(options *driverOptions) {
-	return func(o *driverOptions) {
-		o.address = address
+func logEntyFromOptions(logger *logrus.Logger, options Options) *logrus.Entry {
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "localhost"
 	}
-}
-
-func WithUsername(username string) func(*driverOptions) {
-	return func(o *driverOptions) {
-		o.username = username
-	}
-}
-
-func WithPassword(password string) func(*driverOptions) {
-	return func(o *driverOptions) {
-		o.password = password
-	}
-}
-
-func WithControllerOn(state bool) func(*driverOptions) {
-	return func(o *driverOptions) {
-		o.isController = state
-	}
-}
-
-func WithNodeHost(nodeHost string) func(*driverOptions) {
-	return func(o *driverOptions) {
-		o.nodeHost = nodeHost
-	}
-}
-
-// When building any packages that import version, pass the build/install cmd
-// ldflags like so:
-//   go build -ldflags "-X github.com/UpCloudLtd/upcloud-csi/driver.version=0.0.1"
-
-// TODO look at cleaner way to set these :(.
-var (
-	gitTreeState = "not a git tree" //nolint: gochecknoglobals // set by build
-	commit       string             //nolint: gochecknoglobals // set by build
-	version      string             //nolint: gochecknoglobals // set by build
-)
-
-func GetVersion() string {
-	return version
-}
-
-// GetCommit returns the current commit hash value, as inserted at build time.
-func GetCommit() string {
-	return commit
-}
-
-// GetTreeState returns the current state of git tree, either "clean" or
-// "dirty".
-func GetTreeState() string {
-	return gitTreeState
+	return logger.WithFields(logrus.Fields{
+		"region":   options.Zone,
+		"node_id":  options.NodeHost,
+		"hostname": hostname,
+	})
 }

--- a/driver/filesystem_internal_test.go
+++ b/driver/filesystem_internal_test.go
@@ -1,4 +1,4 @@
-package driver //nolint:testpackage // use conventional naming for now
+package driver
 
 import (
 	"context"

--- a/driver/healthcheck.go
+++ b/driver/healthcheck.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/UpCloudLtd/upcloud-go-api/v5/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud"
+	upsvc "github.com/UpCloudLtd/upcloud-go-api/v6/upcloud/service"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -43,19 +44,23 @@ func (c *HealthChecker) Check(ctx context.Context) error {
 	return eg.Wait()
 }
 
-type upcloudHealthChecker struct {
+type UpcloudHealthChecker struct {
 	account func(cxt context.Context) (*upcloud.Account, error)
 }
 
-func (c *upcloudHealthChecker) Name() string {
+func (c *UpcloudHealthChecker) Name() string {
 	return "upcloud"
 }
 
-func (c *upcloudHealthChecker) Check(ctx context.Context) error {
+func (c *UpcloudHealthChecker) Check(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, healthTimeout*time.Second)
 	defer cancel()
 	if _, err := c.account(ctx); err != nil {
 		return fmt.Errorf("checking health: %w", err)
 	}
 	return nil
+}
+
+func NewUpcloudHealthChecker(svc *upsvc.Service) *UpcloudHealthChecker {
+	return &UpcloudHealthChecker{account: svc.GetAccount}
 }

--- a/driver/identity.go
+++ b/driver/identity.go
@@ -10,7 +10,7 @@ import (
 // GetPluginInfo returns metadata of the plugin.
 func (d *Driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
 	return &csi.GetPluginInfoResponse{
-		Name: d.options.driverName,
+		Name: d.options.DriverName,
 	}, nil
 }
 

--- a/driver/node.go
+++ b/driver/node.go
@@ -251,13 +251,13 @@ func (d *Driver) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabi
 // NodeGetInfo returns the supported capabilities of the node server.
 func (d *Driver) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
 	return &csi.NodeGetInfoResponse{
-		NodeId:            d.options.nodeHost,
+		NodeId:            d.options.NodeHost,
 		MaxVolumesPerNode: maxVolumesPerNode,
 
 		// make sure that the driver works on this particular region only
 		AccessibleTopology: &csi.Topology{
 			Segments: map[string]string{
-				"region": d.options.zone,
+				"region": d.options.Zone,
 			},
 		},
 	}, nil

--- a/driver/node_internal_test.go
+++ b/driver/node_internal_test.go
@@ -1,4 +1,4 @@
-package driver //nolint:testpackage // use conventional naming for now
+package driver
 
 import (
 	"context"

--- a/driver/service.go
+++ b/driver/service.go
@@ -106,12 +106,13 @@ func (u *upCloudService) cloneStorage(ctx context.Context, r *request.CloneStora
 		if err != nil {
 			return s, err
 		}
+		s, err = u.svc.WaitForStorageState(ctx, &request.WaitForStorageStateRequest{
+			UUID:         s.Storage.UUID,
+			DesiredState: upcloud.StorageStateOnline,
+			Timeout:      storageStateTimeout,
+		})
 	}
-	return u.svc.WaitForStorageState(ctx, &request.WaitForStorageStateRequest{
-		UUID:         s.Storage.UUID,
-		DesiredState: upcloud.StorageStateOnline,
-		Timeout:      storageStateTimeout,
-	})
+	return s, err
 }
 
 func (u *upCloudService) deleteStorage(ctx context.Context, storageUUID string) error {

--- a/driver/service_internal_test.go
+++ b/driver/service_internal_test.go
@@ -1,20 +1,20 @@
-package driver //nolint:testpackage // use conventional naming for now
+package driver
 
 import (
 	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
-	"github.com/UpCloudLtd/upcloud-go-api/v5/upcloud"
-	"github.com/UpCloudLtd/upcloud-go-api/v5/upcloud/client"
-	"github.com/UpCloudLtd/upcloud-go-api/v5/upcloud/service"
+	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud/client"
+	upsvc "github.com/UpCloudLtd/upcloud-go-api/v6/upcloud/service"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUpcloudClient_listStorage(t *testing.T) { //nolint:paralleltest // uses t.Setenv
+func TestUpCloudService_listStorage(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `
 		{
@@ -54,10 +54,7 @@ func TestUpcloudClient_listStorage(t *testing.T) { //nolint:paralleltest // uses
 		`)
 	}))
 	defer srv.Close()
-	t.Setenv(client.EnvDebugAPIBaseURL, srv.URL)
-	defer os.Setenv(client.EnvDebugAPIBaseURL, "")
-
-	c := upcloudClient{service.New(client.New("", ""))}
+	c := upCloudService{upsvc.New(client.New("", "", client.WithBaseURL(srv.URL)))}
 	storages, err := c.listStorage(context.Background(), "fi-hel2")
 	if err != nil {
 		t.Error(err)
@@ -91,7 +88,8 @@ func TestUpcloudClient_listStorage(t *testing.T) { //nolint:paralleltest // uses
 	}
 }
 
-func TestUpcloudClient_listStorageBackups(t *testing.T) { //nolint:paralleltest // uses t.Setenv
+func TestUpCloudService_listStorageBackups(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `
 		{
@@ -135,7 +133,7 @@ func TestUpcloudClient_listStorageBackups(t *testing.T) { //nolint:paralleltest 
 	}))
 	defer srv.Close()
 
-	c := upcloudClient{service.New(client.New("", "", client.WithBaseURL(srv.URL)))}
+	c := upCloudService{upsvc.New(client.New("", "", client.WithBaseURL(srv.URL)))}
 	storages, err := c.listStorageBackups(context.Background(), "id1")
 	assert.NoError(t, err)
 	want := []*upcloud.Storage{

--- a/driver/version.go
+++ b/driver/version.go
@@ -1,0 +1,27 @@
+package driver
+
+// When building any packages that import version, pass the build/install cmd
+// ldflags like so:
+//   go build -ldflags "-X github.com/UpCloudLtd/upcloud-csi/driver.version=0.0.1"
+
+// TODO look at cleaner way to set these :(.
+var (
+	gitTreeState = "not a git tree" //nolint: gochecknoglobals // set by build
+	commit       string             //nolint: gochecknoglobals // set by build
+	version      string             //nolint: gochecknoglobals // set by build
+)
+
+func GetVersion() string {
+	return version
+}
+
+// GetCommit returns the current commit hash value, as inserted at build time.
+func GetCommit() string {
+	return commit
+}
+
+// GetTreeState returns the current state of git tree, either "clean" or
+// "dirty".
+func GetTreeState() string {
+	return gitTreeState
+}

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 
 require github.com/kubernetes-csi/csi-test/v5 v5.0.0
 
-require github.com/UpCloudLtd/upcloud-go-api/v5 v5.1.0
+require github.com/UpCloudLtd/upcloud-go-api/v6 v6.0.0
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/UpCloudLtd/upcloud-go-api/v5 v5.1.0 h1:8xsPsKvz88DbP8MPk8q18ZIBoiTzcbGEfmy0ZVsTbrY=
-github.com/UpCloudLtd/upcloud-go-api/v5 v5.1.0/go.mod h1:AujcayelvOLjiwbulTrC0wzbykpsrcNcc1HuZ3Tloek=
+github.com/UpCloudLtd/upcloud-go-api/v6 v6.0.0 h1:q4FYAC9/4hmkTop30XMOBMQfgj5iakTQEFEgc3T6dqE=
+github.com/UpCloudLtd/upcloud-go-api/v6 v6.0.0/go.mod h1:9y8kZ4o4jCagqLfexcnITY8uc/g4+uc18wbnMsDbQJI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=


### PR DESCRIPTION
- update UpCloud Go API to v6.0.0
- add new `--zone` flag that can be used to set zone when fetching zone using node name is not possible
- add new `--label` flag which can be used to apply default labels to all storages created by the driver
- clean up `Driver` type, fix linting problems and naming conventions
- try graceful shutdown when possible
- change default log level from warning to info