### PR TITLE
chore(deploy): use credentials from environment variables

### DIFF
--- a/deploy/kubernetes/setup-upcloud-csi.yaml
+++ b/deploy/kubernetes/setup-upcloud-csi.yaml
@@ -124,8 +124,6 @@ spec:
           args:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodehost=$(NODE_ID)"
-            - "--username=$(UPCLOUD_USERNAME)"
-            - "--password=$(UPCLOUD_PASSWORD)"
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -251,8 +249,6 @@ spec:
           args:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodehost=$(NODE_ID)"
-            - "--username=$(UPCLOUD_USERNAME)"
-            - "--password=$(UPCLOUD_PASSWORD)"
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock


### PR DESCRIPTION
Remove `--username` and `--password` command-line flags from Kubernetes deployment manifest. 
Driver can use [environment variables](https://github.com/UpCloudLtd/upcloud-csi/blob/dd4b96549402e847bac7a77f29a7790965c92a90/deploy/kubernetes/setup-upcloud-csi.yaml#L132-L141) directly. This also hides credentials from showing up in process listing.  