### PR TITLE
chore(build): use Go 1.19 and alpine:3.17 base image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set go environment
         uses: actions/setup-go@v3.0.0
         with:
-          go-version: 1.17.0
+          go-version: 1.19
 
       - name: Build Go binary
         run: GOOS=${{ env.GOOS }} GOARCH=${{ env.GOARCH }} CGO_ENABLED=0 go build -ldflags "-w -s" -o cmd/upcloud-csi-plugin/${{ env.NAME }} ${{ env.PKG }}

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PLUGIN_PKG ?= github.com/UpCloudLtd/upcloud-csi/cmd/upcloud-csi-plugin
 MANIFEST_NAME=upcloud-csi-manifest
 MANIFEST_PKG ?= github.com/UpCloudLtd/upcloud-csi/cmd/upcloud-csi-manifest
 OS ?= linux
-GO_VERSION := 1.17.6
+GO_VERSION := 1.19
 ARCH := amd64
 CGO_ENABLED := 1
 

--- a/cmd/upcloud-csi-plugin/Dockerfile
+++ b/cmd/upcloud-csi-plugin/Dockerfile
@@ -1,5 +1,5 @@
 # Step 1 build
-FROM golang:alpine AS build
+FROM alpine:3.17
 
 RUN apk add ca-certificates \
     e2fsprogs \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/UpCloudLtd/upcloud-csi
 
-go 1.18
+go 1.19
 
 require (
 	github.com/container-storage-interface/spec v1.6.0


### PR DESCRIPTION
- bump Go version from 1.17 to .1.19
- use `alpine` image instead of `golang:alpine` to make images smaller