### PR TITLE
chore(lint): update golangci-lint to v1.52.2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,5 +17,5 @@ jobs:
       - name: Run golangci-lint-action
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.1
+          version: v1.52.2
           args: --timeout 5m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.50.1
+    rev: v1.52.2
     hooks:
       - id: golangci-lint
   - repo: local

--- a/driver/filesystem.go
+++ b/driver/filesystem.go
@@ -183,7 +183,6 @@ func (m *nodeFilesystem) isFormatted(ctx context.Context, source string) (bool, 
 	blkidArgs := []string{source}
 
 	logWithServerContext(ctx, m.log).WithFields(logrus.Fields{logCommandKey: blkidCmd, logCommandArgsKey: blkidArgs}).Debug("executing command")
-	exitCode := 0
 	if err = exec.CommandContext(ctx, blkidCmd, blkidArgs...).Run(); err != nil {
 		var exitError *exec.ExitError
 		if !errors.As(err, &exitError) {
@@ -193,7 +192,7 @@ func (m *nodeFilesystem) isFormatted(ctx context.Context, source string) (bool, 
 		if !ok {
 			return false, fmt.Errorf("checking formatting exit status: %w cmd: %q, args: %q", err, blkidCmd, blkidArgs)
 		}
-		exitCode = ws.ExitStatus()
+		exitCode := ws.ExitStatus()
 		if exitCode == blkidExitStatusNoIdentifiers {
 			return false, nil
 		}


### PR DESCRIPTION
Update to latest golangci-lint and fix linter error in `driver/filesystem.go`:
`assigned to exitCode, but reassigned without using the value (wastedassign)`