### PR TITLE
fix(driver): check if maximum number of attached devices has been reached

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -65,7 +65,7 @@ $ docker run --privileged -it --rm \
 ```
 Open second terminal to server and run test suite
 ```shell
-$ csi-sanity --csi.endpoint=`pwd`/tmp/csi.sock --csi.stagingdir=/mnt/csi-staging --csi.mountdir=/mnt/csi-mount --ginkgo.v --ginkgo.fail-fast
+$ csi-sanity --csi.endpoint=`pwd`/tmp/csi.sock --csi.stagingdir=/mnt/csi-staging --csi.mountdir=/mnt/csi-mount --ginkgo.v --ginkgo.fail-fast -csi.testnodevolumeattachlimit=true
 ```
 Use `-csi.testvolumeaccesstype=block` csi-sanity test option to test block devices instead of volumes.
 

--- a/driver/node.go
+++ b/driver/node.go
@@ -14,7 +14,7 @@ import (
 const (
 	udevDiskByIDPath  = "/dev/disk/by-id"
 	diskPrefix        = "virtio-"
-	maxVolumesPerNode = 7
+	maxVolumesPerNode = 14
 	fileSystemExt4    = "ext4"
 )
 
@@ -266,7 +266,9 @@ func (d *Driver) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabi
 // NodeGetInfo returns the supported capabilities of the node server.
 func (d *Driver) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
 	return &csi.NodeGetInfoResponse{
-		NodeId:            d.options.NodeHost,
+		NodeId: d.options.NodeHost,
+
+		// Maximum number of volumes that controller can publish to the node.
 		MaxVolumesPerNode: maxVolumesPerNode,
 
 		// make sure that the driver works on this particular region only

--- a/driver/service.go
+++ b/driver/service.go
@@ -21,7 +21,7 @@ var (
 )
 
 type service interface { //nolint:interfacebloat // Split this to smaller piece when it makes sense code wise
-	getServerByHostname(context.Context, string) (*upcloud.Server, error)
+	getServerByHostname(context.Context, string) (*upcloud.ServerDetails, error)
 	getStorageByUUID(context.Context, string) (*upcloud.StorageDetails, error)
 	getStorageByName(context.Context, string) ([]*upcloud.StorageDetails, error)
 	listStorage(context.Context, string) ([]upcloud.Storage, error)
@@ -181,7 +181,7 @@ func (u *upCloudService) listStorage(ctx context.Context, zone string) ([]upclou
 	return zoneStorage, nil
 }
 
-func (u *upCloudService) getServerByHostname(ctx context.Context, hostname string) (*upcloud.Server, error) {
+func (u *upCloudService) getServerByHostname(ctx context.Context, hostname string) (*upcloud.ServerDetails, error) {
 	servers, err := u.svc.GetServers(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch servers: %w", err)
@@ -189,7 +189,9 @@ func (u *upCloudService) getServerByHostname(ctx context.Context, hostname strin
 
 	for _, server := range servers.Servers {
 		if server.Hostname == hostname {
-			return &server, nil
+			return u.svc.GetServerDetails(ctx, &request.GetServerDetailsRequest{
+				UUID: server.UUID,
+			})
 		}
 	}
 

--- a/driver/test_utils.go
+++ b/driver/test_utils.go
@@ -120,9 +120,13 @@ func (m *mockUpCloudService) listStorage(ctx context.Context, zone string) ([]up
 	}, nil
 }
 
-func (m *mockUpCloudService) getServerByHostname(ctx context.Context, hostname string) (*upcloud.Server, error) {
+func (m *mockUpCloudService) getServerByHostname(ctx context.Context, hostname string) (*upcloud.ServerDetails, error) {
 	id, _ := uuid.NewUUID()
-	return &upcloud.Server{UUID: id.String()}, nil
+	return &upcloud.ServerDetails{
+		Server: upcloud.Server{
+			UUID: id.String(),
+		},
+	}, nil
 }
 
 func (m *mockUpCloudService) resizeStorage(ctx context.Context, _ string, newSize int, deleteBackup bool) (*upcloud.StorageDetails, error) {


### PR DESCRIPTION
- increase maximum number of volumes per node from 7 to 14
- return `codes.ResourceExhausted` if disk device limit has been reached