### PR TITLE
fix(filesystem): make filesystem formating idempotent

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -36,7 +36,10 @@ func newPluginServer(c config.Config, l *logrus.Entry) (*server.PluginServer, er
 	var srv *server.PluginServer
 	var err error
 	if c.Filesystem == nil {
-		c.Filesystem = filesystem.NewLinuxFilesystem(c.FilesystemTypes, l)
+		c.Filesystem, err = filesystem.NewLinuxFilesystem(c.FilesystemTypes, l)
+		if err != nil {
+			return nil, err
+		}
 	}
 	switch c.Mode {
 	case config.DriverModeController:

--- a/internal/plugin/plugin_internal_test.go
+++ b/internal/plugin/plugin_internal_test.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"testing"
 
+	"github.com/UpCloudLtd/upcloud-csi/internal/filesystem/mock"
 	"github.com/UpCloudLtd/upcloud-csi/internal/logger"
 	"github.com/UpCloudLtd/upcloud-csi/internal/plugin/config"
 	"github.com/stretchr/testify/require"
@@ -19,6 +20,7 @@ func TestNewPluginServer(t *testing.T) {
 		Mode:                config.DriverModeController,
 		Zone:                "fi-hel2",
 		PluginServerAddress: config.DefaultPluginServerAddress,
+		Filesystem:          &mock.MockFilesystem{},
 	}
 	srv, err := newPluginServer(cfg, l.WithField("package", "plugin"))
 	require.NoError(t, err)
@@ -31,6 +33,7 @@ func TestNewPluginServer(t *testing.T) {
 		NodeHost:            hostname(),
 		PluginServerAddress: config.DefaultPluginServerAddress,
 		Zone:                "fi-hel2",
+		Filesystem:          &mock.MockFilesystem{},
 	}
 	srv, err = newPluginServer(cfg, l.WithField("package", "plugin"))
 	require.NoError(t, err)
@@ -45,6 +48,7 @@ func TestNewPluginServer(t *testing.T) {
 		NodeHost:            hostname(),
 		PluginServerAddress: config.DefaultPluginServerAddress,
 		Zone:                "fi-hel2",
+		Filesystem:          &mock.MockFilesystem{},
 	}
 	srv, err = newPluginServer(cfg, l.WithField("package", "plugin"))
 	require.NoError(t, err)


### PR DESCRIPTION
- make filesystem formating idempotent
- check that all system tools are available when creating new Linux filesystem instance
- wait until server is in `started` state when attaching and detaching storage devices
- improve filesystem error reporting