### PR TITLE
fix(controller): regard volume as unpublished from the node, if node is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+- controller: regard volume as unpublished from the node, if node is not found
+
 ## [1.0.0]
 
 First stable release

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -305,6 +305,7 @@ func (c *Controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 	_, err := c.svc.GetStorageByUUID(ctx, req.GetVolumeId())
 	if err != nil {
 		if errors.Is(err, service.ErrStorageNotFound) {
+			log.Info("storage not found")
 			return &csi.ControllerUnpublishVolumeResponse{}, nil
 		}
 		return nil, err
@@ -314,6 +315,10 @@ func (c *Controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 	log.Info("getting server by hostname")
 	server, err := c.svc.GetServerByHostname(ctx, req.GetNodeId())
 	if err != nil {
+		if errors.Is(err, service.ErrServerNotFound) {
+			log.Info("server not found")
+			return &csi.ControllerUnpublishVolumeResponse{}, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
This aligns `ControllerUnpublishVolume` with the [spec](https://github.com/container-storage-interface/spec/blob/master/spec.md#controllerunpublishvolume)  


> If the volume corresponding to the volume_id or **the node corresponding to node_id cannot be found** by the Plugin and the volume can be safely regarded as ControllerUnpublished from the node, the plugin SHOULD return 0 OK