### PR TITLE
fix: wait for storage online to do resizing and improve error logging

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -613,13 +613,13 @@ func (c *Controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		log.Info("resizing block device")
 		_, err = c.svc.ResizeBlockDevice(ctx, volume.UUID, int(resizeGigaBytes))
 		if err != nil {
-			c.log.Errorf("cannot resizeBlockDevice volume %s: %s", volumeID, err.Error())
+			return nil, status.Errorf(codes.Internal, "cannot resizeBlockDevice volume %s: %s", volumeID, err.Error())
 		}
 	} else {
 		log.Info("resizing volume")
 		_, err = c.svc.ResizeStorage(ctx, volume.UUID, int(resizeGigaBytes), false)
 		if err != nil {
-			c.log.Errorf("cannot resizeStorage volume %s: %s", volumeID, err.Error())
+		    return nil, status.Errorf(codes.Internal, "cannot resizeStorage volume %s: %s", volumeID, err.Error())
 		}
 	}
 

--- a/internal/service/upcloud_service.go
+++ b/internal/service/upcloud_service.go
@@ -227,6 +227,10 @@ func (u *UpCloudService) ResizeStorage(ctx context.Context, uuid string, newSize
 		return nil, err
 	}
 
+	if _, err = u.waitForStorageOnline(ctx, storage.Storage.UUID); err != nil {
+		return nil, err
+	}
+
 	backup, err := u.client.ResizeStorageFilesystem(ctx, &request.ResizeStorageFilesystemRequest{UUID: uuid})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The CSI is buggy with filesystem resizing, because it doesn't always happen. Waiting for the storage volume to be ready could fix it.

Improved the error logging in controller.go as well so an error during resizing is properly returned.